### PR TITLE
Poll a specific job number

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ async function getJobStatus(jobName, buildNumber) {
 async function waitJenkinsJob(jobName, timestamp) {
   let buildNumber = undefined
   core.info(`>>> Waiting for "${jobName}" ...`);
+  await sleep(10) // wait for the new job to show up under lastBuild
   while (true) {
     let data = await getJobStatus(jobName, buildNumber);
     if (!buildNumber && data.number) {

--- a/index.js
+++ b/index.js
@@ -63,8 +63,9 @@ async function waitJenkinsJob(jobName, timestamp) {
   core.info(`>>> Waiting for "${jobName}" ...`);
   while (true) {
     let data = await getJobStatus(jobName, buildNumber);
-    if (data.number) {
+    if (!buildNumber && data.number) {
       buildNumber = data.number
+      core.info(`>>> Using build number ${buildNumber}`)
     }
     if (data.timestamp < timestamp) {
       core.info(`>>> Job is not started yet... Wait 5 seconds more...`)

--- a/index.js
+++ b/index.js
@@ -39,11 +39,11 @@ async function requestJenkinsJob(jobName, params) {
   );
 }
 
-async function getJobStatus(jobName) {
+async function getJobStatus(jobName, buildNumber) {
   const jenkinsEndpoint = core.getInput('url');
   const req = {
     method: 'get',
-    url: `${jenkinsEndpoint}/job/${jobName}/lastBuild/api/json`,
+    url: `${jenkinsEndpoint}/job/${jobName}/${buildNumber || 'lastBuild'}/api/json`,
     headers: {
       'Authorization': `Basic ${API_TOKEN}`
     }
@@ -59,9 +59,13 @@ async function getJobStatus(jobName) {
     );
 }
 async function waitJenkinsJob(jobName, timestamp) {
+  let buildNumber = undefined
   core.info(`>>> Waiting for "${jobName}" ...`);
   while (true) {
-    let data = await getJobStatus(jobName);
+    let data = await getJobStatus(jobName, buildNumber);
+    if (data.number) {
+      buildNumber = data.number
+    }
     if (data.timestamp < timestamp) {
       core.info(`>>> Job is not started yet... Wait 5 seconds more...`)
     } else if (data.result == "SUCCESS") {


### PR DESCRIPTION
Since this plugin always checks `${jobName}/lastBuild` for the status, if another build starts before the one we triggered finishes, we'll end up polling that one for status instead. This waits 10 seconds after triggering a build, then grabs the build number of the most recent build, and polls that for status.